### PR TITLE
Environment Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ eg. [sudo -E] python osxauditor.py -a -m -l localhashes.db -H log.html
 
 ### Setting Environment Variables
 
-VirusTotal:
+[VirusTotal API](https://www.virustotal.com/en/documentation/public-api/):
 > export VT_API_KEY=aaaabbbbccccddddeeee
 
-Malware.lu:
+Malware.lu API Key:
 > export MALWARE_LU_API_KEY=aaaabbbbccccddddeeee
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Malware.lu API Key:
 
 ## Changelog
 
+### 0.4.2
+ * Moved API keys from in the code to environment variables
+
 ### 0.4.1
  * CHANGE: Search for generic backdoors in LaunchAgentPlist
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,19 @@ These dependencies will be removed when a working native plist module will be av
  * OS X Auditor runs well with python >= 2.7.2 (2.7.5 is OK). It does not run with a different version of python yet (due to the plist nightmare)
  * OS X Auditor is written to work on Moutain Lion. It will do his best on older OS X versions.
  * You must run it as root (or via sudo) if you want to use is on a running system, otherwise it won't be able to access some system and other users' files
+ * If you're using API keys from environment variables (see below), you need to use the ```sudo -E``` to use the users environment variables
 
 Type osxauditor.py -h to get all the available options, then run it with the selected options
 
-eg. [sudo] python osxauditor.py -a -m -l localhashes.db -H log.html
+eg. [sudo -E] python osxauditor.py -a -m -l localhashes.db -H log.html
+
+### Setting Environment Variables
+
+VirusTotal:
+> export VT_API_KEY=aaaabbbbccccddddeeee
+
+Malware.lu:
+> export MALWARE_LU_API_KEY=aaaabbbbccccddddeeee
 
 ## Changelog
 

--- a/osxauditor.py
+++ b/osxauditor.py
@@ -9,7 +9,7 @@
 
 __description__ = 'OS X Auditor'
 __author__ = '@Jipe_'
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 
 ROOT_PATH = "/"
 HOSTNAME = ""

--- a/osxauditor.py
+++ b/osxauditor.py
@@ -36,13 +36,11 @@ MRH_HOST = u"hash.cymru.com"
 MRH_PORT = 43
 
 MALWARE_LU_HOST = u"https://www.malware.lu/api/check"
-MALWARE_LU_API_KEY = ""											#Put your malware.lu API key here
 
 GEOLOCATE_WIFI_AP = False
 GEOMENA_API_HOST = u"http://geomena.org/ap/"
 
 VT_HOST = u"https://www.virustotal.com/vtapi/v2/file/report"
-VT_API_KEY  = u""												#Put your VirusTotal API key here
 
 ADMINS = []
 
@@ -62,6 +60,9 @@ from functools import partial
 import re
 import bz2
 import binascii
+
+MALWARE_LU_API_KEY = ""											#Put your malware.lu API key here
+VT_API_KEY  = u""												#Put your VirusTotal API key here
 
 try:
 	from urllib.request import urlopen							#python3

--- a/osxauditor.py
+++ b/osxauditor.py
@@ -61,8 +61,8 @@ import re
 import bz2
 import binascii
 
-MALWARE_LU_API_KEY = ""											#Put your malware.lu API key here
-VT_API_KEY  = u""												#Put your VirusTotal API key here
+MALWARE_LU_API_KEY = os.getenv('MALWARE_LU_APT_KEY', False)
+VT_API_KEY  = os.getenv('VT_API_KEY', False)
 
 try:
 	from urllib.request import urlopen							#python3


### PR DESCRIPTION
It's a core tenant of the [12 Factor app that configuration should not be stored in code](http://12factor.net). Given this is especially key with authentication tokens such as API tokens I pulled the Malware.lu & VirusTotal API keys out of the code and suggested they be added as environment variables. 

If they're available they'll be read in, otherwise they'll be assigned the primitive ```False``` causing the same failure condition as before. I also updated the documentation to make sure users understand how to set this up.