### PR TITLE
Fixed issue related to getting email port number

### DIFF
--- a/osxauditor.py
+++ b/osxauditor.py
@@ -1002,7 +1002,7 @@ def ParseMailAppAccount(MailAccountPlistPath):
                     if 'SSLEnabled' in DeliveryAccount: DAccountPref += 'SSLEnabled: ' + DeliveryAccount['SSLEnabled'] + ' - '
                     if 'Username' in DeliveryAccount: DAccountPref += 'Username: ' + DeliveryAccount['Username']  + ' - '
                     if 'Hostname' in DeliveryAccount: DAccountPref += 'Hostname: ' + DeliveryAccount['Hostname']  + ' - '
-                    if 'PortNumber' in DeliveryAccount: DAccountPref += '(' + str(MailAccount['PortNumber'])  + ') - '
+                    if 'PortNumber' in DeliveryAccount: DAccountPref += '(' + str(DeliveryAccount['PortNumber'])  + ') - '
                     PrintAndLog(DAccountPref.decode('utf-8'), 'INFO')
                 NbSmtpAccounts += 1
             if NbSmtpAccounts == 0:


### PR DESCRIPTION
The check of the existence of the port number was not related with the actual object containing the data, which resulted in a crash.